### PR TITLE
Add wealth distance visualizer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # DevOps_Engineering
 A repo for various files and scripts, incomplete, in progress, abandoned or just want to keep for some unknown reason
+
+## Wealth Distance Visualizer
+A simple static web app for comparing net worth along the path from Santa Monica Pier to Boston Pleasure Bay. Open `wealth_visualizer/index.html` in a browser and enter a net worth to see how far along the 3,000 mile journey it would take you.

--- a/wealth_visualizer/index.html
+++ b/wealth_visualizer/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wealth Distance Visualizer</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2tGgWcGp1rH/87b5iVb6BsO8su1YPnRfuBjCZoM=" crossorigin="">
+</head>
+<body>
+    <h1>Wealth Distance Visualizer</h1>
+    <div id="controls">
+        <label for="netWorth">Enter your net worth (USD): </label>
+        <input type="number" id="netWorth" placeholder="e.g., 500000">
+        <button id="showBtn">Show on Map</button>
+        <p id="result"></p>
+    </div>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7Q5bbR5brZyjKdwfVmZ60p1Nw52xR5x0iCmZos=" crossorigin=""></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/wealth_visualizer/main.js
+++ b/wealth_visualizer/main.js
@@ -1,0 +1,94 @@
+// Coordinates roughly following a drive from Santa Monica Pier to Boston Pleasure Bay
+const routeCoords = [
+    [34.0095, -118.4973], // Santa Monica Pier
+    [36.1699, -115.1398], // Las Vegas
+    [39.7392, -104.9903], // Denver
+    [41.2565, -95.9345],  // Omaha
+    [41.8781, -87.6298],  // Chicago
+    [41.4993, -81.6944],  // Cleveland
+    [42.8864, -78.8784],  // Buffalo
+    [42.6526, -73.7562],  // Albany
+    [42.3369, -71.0351]   // Boston Pleasure Bay
+];
+
+// Haversine distance in miles
+function haversine(a, b) {
+    const toRad = deg => deg * Math.PI / 180;
+    const R = 3958.8; // Earth radius in miles
+    const dLat = toRad(b[0] - a[0]);
+    const dLon = toRad(b[1] - a[1]);
+    const lat1 = toRad(a[0]);
+    const lat2 = toRad(b[0]);
+    const h = Math.sin(dLat/2)**2 + Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;
+    return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+function totalDistance(coords) {
+    let dist = 0;
+    for (let i = 0; i < coords.length - 1; i++) {
+        dist += haversine(coords[i], coords[i+1]);
+    }
+    return dist;
+}
+
+const ROUTE_DISTANCE_MILES = totalDistance(routeCoords);
+
+function pointAtDistance(coords, distance) {
+    let dist = 0;
+    for (let i = 0; i < coords.length - 1; i++) {
+        const seg = haversine(coords[i], coords[i+1]);
+        if (dist + seg >= distance) {
+            const ratio = (distance - dist) / seg;
+            return [
+                coords[i][0] + (coords[i+1][0] - coords[i][0]) * ratio,
+                coords[i][1] + (coords[i+1][1] - coords[i][1]) * ratio
+            ];
+        }
+        dist += seg;
+    }
+    return coords[coords.length - 1];
+}
+
+const map = L.map('map').setView([39.5, -98.35], 4);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const routeLine = L.polyline(routeCoords, {color: 'blue'}).addTo(map);
+map.fitBounds(routeLine.getBounds());
+
+const markersGroup = L.layerGroup().addTo(map);
+
+function updateMap(netWorth) {
+    markersGroup.clearLayers();
+    const fraction = netWorth / 1_000_000_000;
+    const dist = ROUTE_DISTANCE_MILES * fraction;
+    const point = pointAtDistance(routeCoords, dist);
+    L.marker(point).addTo(markersGroup).bindPopup(`Your position: ${dist.toFixed(2)} miles`);
+    document.getElementById('result').textContent = `You would travel ${dist.toFixed(2)} miles out of ${ROUTE_DISTANCE_MILES.toFixed(0)} miles.`;
+
+    // Benchmarks
+    const benchmarks = [
+        {name: '$1M', value: 1_000_000},
+        {name: '$10M', value: 10_000_000},
+        {name: '$50M', value: 50_000_000},
+        {name: '$100M', value: 100_000_000},
+        {name: '$500M', value: 500_000_000},
+        {name: '$1B', value: 1_000_000_000}
+    ];
+    benchmarks.forEach(b => {
+        const bDist = ROUTE_DISTANCE_MILES * (b.value / 1_000_000_000);
+        const bPoint = pointAtDistance(routeCoords, bDist);
+        L.circleMarker(bPoint, {radius:4, color:'red'}).addTo(markersGroup)
+            .bindPopup(`${b.name} (${bDist.toFixed(1)} mi)`);
+    });
+}
+
+document.getElementById('showBtn').addEventListener('click', () => {
+    const value = Number(document.getElementById('netWorth').value);
+    if (isNaN(value) || value <= 0) {
+        alert('Please enter a positive number');
+        return;
+    }
+    updateMap(value);
+});

--- a/wealth_visualizer/style.css
+++ b/wealth_visualizer/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+#controls {
+    padding: 10px;
+    background: #f4f4f4;
+}
+
+#map {
+    width: 100%;
+    height: 80vh;
+}


### PR DESCRIPTION
## Summary
- Add simple Leaflet-based web app to compare net worth along a Santa Monica to Boston road trip
- Document new visualizer in README

## Testing
- `node --check wealth_visualizer/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689797712e7483259d79d377de4111aa